### PR TITLE
feat: simplify package cards with detailed contents

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,36 +100,33 @@
     h2{font-size:clamp(1.2rem,4vw,1.8rem);margin:0 0 18px 0;font-weight:900}
 
     .grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:14px}
-    .card{background:var(--card);padding:14px;border-radius:10px;border:1px solid rgba(255,255,255,0.03);transition:box-shadow .18s ease,transform .12s ease}
+    .card{position:relative;border-radius:10px;overflow:hidden;aspect-ratio:1/1;border:1px solid rgba(255,255,255,0.03);transition:box-shadow .18s ease,transform .18s ease}
     .card:hover{box-shadow:0 6px 18px var(--accent);transform:translateY(-3px)}
-    .card img{width:100%;height:140px;object-fit:cover;border-radius:8px;margin-bottom:10px}
-    .card h3{margin:6px 0 0 0;font-size:1rem;font-weight:700}
+    .card img{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;transition:transform .4s ease}
+    .card:hover img{transform:scale(1.03)}
+    .card .overlay{position:absolute;inset:0;background:linear-gradient(to top,rgba(0,0,0,0.55),rgba(0,0,0,0.15));display:flex;flex-direction:column;justify-content:flex-end;padding:14px}
+    .card h3{margin:0;font-size:1rem;font-weight:700}
+    .features{list-style:disc;margin:8px 0 0 18px;padding:0;text-transform:none;font-size:0.8rem;line-height:1.4;color:var(--muted)}
+    .price-row{display:flex;justify-content:space-between;align-items:center;margin-top:8px}
+    .price{color:var(--green);font-weight:900;font-size:1rem}
 
     /* Vælg pakke-knapper */
-    .choose-btn {
-    display: inline-block;
-    margin-top: 10px;
-    padding: 10px 18px;
-    font-weight: 900;
-    color: var(--green);
-    border: 2px solid var(--green);
-    border-radius: 8px;
-    text-decoration: none;
-    background: transparent;
-    transition: all 0.2s ease;
+    .choose-btn{
+    display:inline-block;
+    flex:1;
+    padding:6px 12px;
+    font-weight:900;
+    color:var(--green);
+    border:2px solid var(--green);
+    border-radius:8px;
+    text-decoration:none;
+    background:rgba(0,0,0,0.4);
+    transition:all 0.2s ease;
+    text-align:center;
     }
 
-    .choose-btn:hover {
-    background: var(--green);
-    color: #000;
-    box-shadow: 0 0 12px var(--green);
-    transform: translateY(-2px);
-    }
-
-    .choose-btn:active {
-    transform: translateY(0);
-    box-shadow: none;
-    }
+    .choose-btn:hover{background:var(--green);color:#000;box-shadow:0 0 12px var(--green);transform:translateY(-2px)}
+    .choose-btn:active{transform:translateY(0);box-shadow:none}
 
 
     /* Contact area: buttons styled like text but are actual buttons to ensure a real user gesture */
@@ -178,18 +175,7 @@
     transform: translateY(0);
     }
 
-    .price-row {
-    display: flex;
-    align-items: center;
-    gap: 40px;
-    margin-top: 10px;
-    }
-
-    .price {
-    color: var(--green);
-    font-weight: 900;
-    font-size: 1rem;
-    }
+    /* old price-row rules removed - new styles defined above */
 
         /* Brugermenu styling */
     .user-menu {
@@ -351,31 +337,60 @@
       <h2>[ PAKKER ]</h2>
       <div class="grid">
         <div class="card">
-          <img src="assets/img/pakke-1.jpg" alt="Pakkebillede 1">
-          <h3>[ DEN LILLE PAKKE ]</h3>
-          <p class="muted">Kan levere klar lyd med god fast bund op til cirka 25 mennesker.</p>
-             <div class="price-row">
-                 <a href="pakke1.html" class="choose-btn">[ VÆLG PAKKE ]</a>
-                 <span class="price">500 kr.</span>
+          <img src="assets/img/pakke-1.jpg" alt="Den Lille Pakke">
+          <div class="overlay">
+            <h3>[ DEN LILLE PAKKE ]</h3>
+            <ul class="features">
+              <li>1 × Yamaha DXR12</li>
+              <li>1 × Yamaha DXS12</li>
+              <li>Bluetooth receiver</li>
+              <li>Stativer</li>
+              <li>Opsætningsguide</li>
+              <li>Diverse kabler</li>
+            </ul>
+            <div class="price-row">
+              <a href="pakke1.html" class="choose-btn">[ VÆLG PAKKE ]</a>
+              <span class="price">500 kr.</span>
             </div>
+          </div>
         </div>
         <div class="card">
-          <img src="assets/img/pakke-2.jpg" alt="Pakkebillede 2">
-          <h3>[ DEN UDVIDET PAKKE ]</h3>
-          <p class="muted">Kan levere gennemtrængende lyd op til cirka 50 mennesker.</p>
+          <img src="assets/img/pakke-2.jpg" alt="Den Store Pakke">
+          <div class="overlay">
+            <h3>[ DEN STORE PAKKE ]</h3>
+            <ul class="features">
+              <li>2 × Yamaha DXR12</li>
+              <li>1 × Yamaha DXS12</li>
+              <li>Bluetooth receiver</li>
+              <li>Stativer</li>
+              <li>Opsætningsguide</li>
+              <li>Diverse kabler</li>
+            </ul>
             <div class="price-row">
-                 <a href="pakke2.html" class="choose-btn">[ VÆLG PAKKE ]</a>
-                 <span class="price">1000 kr.</span>
+              <a href="pakke2.html" class="choose-btn">[ VÆLG PAKKE ]</a>
+              <span class="price">1000 kr.</span>
             </div>
+          </div>
         </div>
         <div class="card">
-          <img src="assets/img/pakke-3.jpg" alt="Pakkebillede 3">
-          <h3>[ DEN STORE PAKKE ]</h3>
-          <p class="muted">Kan levere fantastisk lyd op til cirka 75 mennesker.</p>
+          <img src="assets/img/pakke-3.jpg" alt="Ikke et Øje Tørt Pakke">
+          <div class="overlay">
+            <h3>[ IKKE ET ØJE TØRT PAKKE ]</h3>
+            <ul class="features">
+              <li>2 × Yamaha DXR12</li>
+              <li>1 × Yamaha DXS12</li>
+              <li>2 × DB Technologies B-Hype 12</li>
+              <li>Bluetooth receiver</li>
+              <li>Stativer</li>
+              <li>Opsætningsguide</li>
+              <li>Diverse kabler</li>
+            </ul>
             <div class="price-row">
-                <a href="pakke3.html" class="choose-btn">[ VÆLG PAKKE ]</a>
-                <span class="price">1500 kr.</span>
-         </div>
+              <a href="pakke3.html" class="choose-btn">[ VÆLG PAKKE ]</a>
+              <span class="price">1500 kr.</span>
+            </div>
+          </div>
+        </div>
       </div>
     </section>
 


### PR DESCRIPTION
## Summary
- show square package cards with subtle overlay and muted bullet list for clean, symmetrical look
- add full equipment lists for Den Lille, Den Store, and Ikke Et Øje Tørt packages
- tone down hover effects while keeping select button and price row consistent

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aceab7a9b0832b8759fe007d8c0c0f