### PR TITLE
Style package detail pages with hover effects

### DIFF
--- a/assets/css/pakke.css
+++ b/assets/css/pakke.css
@@ -1,0 +1,76 @@
+:root{
+  --bg:#000;
+  --card:#111;
+  --muted:rgba(255,255,255,0.75);
+  --accent:rgba(0,255,136,0.12);
+  --accent-strong:rgba(0,255,136,0.22);
+  --green:#00ff88;
+}
+*{box-sizing:border-box}
+html,body{height:100%}
+body{
+  margin:0;
+  font-family:Montserrat,system-ui,Arial,sans-serif;
+  background:var(--bg);
+  color:#fff;
+  text-transform:uppercase;
+  -webkit-font-smoothing:antialiased;
+  -moz-osx-font-smoothing:grayscale;
+}
+header{
+  display:flex;
+  justify-content:space-between;
+  align-items:center;
+  padding:18px 18px;
+  gap:12px;
+  position:sticky;top:0;background:transparent;z-index:20;
+  border-bottom:1px solid rgba(255,255,255,0.03)
+}
+.logo{font-weight:900;font-size:1.1rem;cursor:pointer}
+nav{display:flex;gap:10px;align-items:center;flex-wrap:wrap}
+nav a{
+  color:#fff;text-decoration:none;font-weight:700;letter-spacing:1px;
+  padding:6px 10px;border-radius:6px;border:1px solid rgba(255,255,255,0.06);
+  background:transparent;font-size:0.9rem;transition:all 0.2s ease;
+}
+nav a:hover{
+  color:#000;background:var(--green);border-color:var(--green);
+  box-shadow:0 0 10px var(--green);transform:translateY(-2px);
+}
+nav a:active{transform:translateY(0);box-shadow:none}
+.login-btn{
+  padding:6px 12px;border-radius:6px;border:2px solid #fff;background:transparent;
+  color:#fff;font-weight:900;cursor:pointer
+}
+.login-btn:active{transform:translateY(1px)}
+
+main{max-width:1100px;margin:40px auto;padding:0 18px}
+
+.package-layout{
+  display:grid;grid-template-columns:1fr 300px;gap:20px;align-items:start;
+}
+.package-image{background:var(--card);border-radius:10px;padding:10px}
+.package-image img{width:100%;border-radius:8px;display:block}
+.package-desc{margin-top:14px;color:var(--muted);font-weight:400;text-transform:none}
+.package-info{background:var(--card);border-radius:10px;padding:18px;
+  border:1px solid rgba(255,255,255,0.06)}
+.package-info h2{font-size:1.2rem;font-weight:900;margin:0 0 10px}
+.package-info ul{list-style:none;padding:0;margin:0}
+.package-info ul li{
+  background:rgba(255,255,255,0.05);margin:0.5rem 0;padding:0.5rem 1rem;
+  border-left:3px solid var(--green);text-transform:none;transition:background .2s ease,transform .2s ease;
+}
+.package-info ul li:hover{background:var(--accent-strong);transform:translateX(4px)}
+.price{color:var(--green);font-weight:900;margin-top:12px}
+
+.contact-list{display:flex;flex-direction:column;gap:10px}
+.contact-row{display:flex;align-items:center;gap:10px}
+.contact-emoji{font-size:1.1rem}
+.copy-btn{background:transparent;border:0;color:#fff;font-weight:700;letter-spacing:0.6px;padding:8px 10px;border-radius:6px;cursor:pointer;text-align:left;font-size:0.98rem}
+.copy-btn:hover{background:var(--accent)}
+
+.muted{color:var(--muted);font-weight:400;font-size:0.9rem}
+footer{padding:30px 18px;text-align:center;color:rgba(255,255,255,0.6);font-size:0.8rem}
+#toast{position:fixed;left:50%;transform:translateX(-50%);bottom:22px;background:#111;padding:10px 16px;border-radius:10px;border:1px solid rgba(255,255,255,0.06);opacity:0;pointer-events:none;transition:opacity .25s ease;z-index:60}
+
+@media (max-width:768px){.package-layout{grid-template-columns:1fr}}

--- a/pakke1.html
+++ b/pakke1.html
@@ -5,145 +5,19 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Den Lille Pakke - [ LYDSTYRKEN ]</title>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700;900&display=swap" rel="stylesheet">
-  <style>
-    :root{
-      --bg:#000;
-      --card:#111;
-      --muted:rgba(255,255,255,0.75);
-      --accent:rgba(0,255,136,0.12);
-      --accent-strong:rgba(0,255,136,0.22);
-      --green:#00ff88;
-    }
-    *{box-sizing:border-box}
-    html,body{height:100%}
-    body{
-      margin:0;
-      font-family:Montserrat,system-ui,Arial,sans-serif;
-      background:var(--bg);
-      color:#fff;
-      text-transform:uppercase;
-      -webkit-font-smoothing:antialiased;
-      -moz-osx-font-smoothing:grayscale;
-    }
-    header{
-      display:flex;
-      justify-content:space-between;
-      align-items:center;
-      padding:18px 18px;
-      gap:12px;
-      position:sticky;top:0;background:transparent;z-index:20;
-      border-bottom:1px solid rgba(255,255,255,0.03)
-    }
-    .logo{font-weight:900;font-size:1.1rem;cursor:pointer}
-    nav{display:flex;gap:10px;align-items:center;flex-wrap:wrap}
-    nav a{
-      color:#fff;text-decoration:none;font-weight:700;letter-spacing:1px;
-      padding:6px 10px;border-radius:6px;border:1px solid rgba(255,255,255,0.06);
-      background:transparent;font-size:0.9rem;
-      transition: all 0.2s ease;
-    }
-    nav a:hover {
-      color: #000;
-      background: var(--green);
-      border-color: var(--green);
-      box-shadow: 0 0 10px var(--green);
-      transform: translateY(-2px);
-    }
-    nav a:active {
-      transform: translateY(0);
-      box-shadow: none;
-    }
-    .login-btn{
-      padding:6px 12px;border-radius:6px;border:2px solid #fff;background:transparent;color:#fff;font-weight:900;cursor:pointer
-    }
-    .login-btn:active{transform:translateY(1px)}
-
-    main{max-width:1100px;margin:40px auto;padding:0 18px}
-
-    /* Pakke layout */
-    .package-layout {
-      display: grid;
-      grid-template-columns: 1fr 300px;
-      gap: 20px;
-      align-items: start;
-    }
-    .package-image {
-      background: var(--card);
-      border-radius: 10px;
-      padding: 10px;
-    }
-    .package-image img {
-      width: 100%;
-      border-radius: 8px;
-      display: block;
-    }
-    .package-desc {
-      margin-top: 14px;
-      color: var(--muted);
-      font-weight: 400;
-      text-transform: none;
-    }
-    .package-info {
-      background: var(--card);
-      border-radius: 10px;
-      padding: 18px;
-      border: 1px solid rgba(255,255,255,0.06);
-    }
-    .package-info h2 {
-      font-size: 1.2rem;
-      font-weight: 900;
-      margin: 0 0 10px;
-    }
-    .package-info ul {
-      list-style: none;
-      padding: 0;
-      margin: 0;
-    }
-    .package-info ul li {
-      background: rgba(255,255,255,0.05);
-      margin: 0.5rem 0;
-      padding: 0.5rem 1rem;
-      border-left: 3px solid var(--green);
-      text-transform: none;
-    }
-    .price {
-      color: var(--green);
-      font-weight: 900;
-      margin-top: 12px;
-    }
-
-    /* Kontakt */
-    .contact-list{display:flex;flex-direction:column;gap:10px}
-    .contact-row{display:flex;align-items:center;gap:10px}
-    .contact-emoji{font-size:1.1rem}
-    .copy-btn{
-      background:transparent;border:0;color:#fff;font-weight:700;letter-spacing:0.6px;padding:8px 10px;border-radius:6px;cursor:pointer;text-align:left;font-size:0.98rem
-    }
-    .copy-btn:hover{background:var(--accent)}
-
-    .muted{color:var(--muted);font-weight:400;font-size:0.9rem}
-    footer{padding:30px 18px;text-align:center;color:rgba(255,255,255,0.6);font-size:0.8rem}
-    #toast{position:fixed;left:50%;transform:translateX(-50%);bottom:22px;background:#111;padding:10px 16px;border-radius:10px;border:1px solid rgba(255,255,255,0.06);opacity:0;pointer-events:none;transition:opacity .25s ease;z-index:60}
-
-    @media (max-width: 768px) {
-      .package-layout {
-        grid-template-columns: 1fr;
-      }
-    }
-  </style>
+  <link rel="stylesheet" href="assets/css/pakke.css">
 </head>
 <body>
-    <header>
+  <header>
     <div class="logo" onclick="window.location.href='index.html'">[ LYDSTYRKEN ]</div>
     <nav aria-label="Hovednavigation">
-        <a href="index.html#pakker">[ PAKKER ]</a>
-        <a href="#">[ BYG SELV ]</a> <!-- Beholder tomt link indtil siden laves -->
-        <a href="index.html#hvem">[ HVEM ER VI? ]</a>
-        <a href="index.html#kontakt">[ KONTAKT ]</a>
-        <button class="login-btn" id="loginBtn">[ LOG IND ]</button>
+      <a href="index.html#pakker">[ PAKKER ]</a>
+      <a href="#">[ BYG SELV ]</a>
+      <a href="index.html#hvem">[ HVEM ER VI? ]</a>
+      <a href="index.html#kontakt">[ KONTAKT ]</a>
+      <button class="login-btn" id="loginBtn">[ LOG IND ]</button>
     </nav>
-    </header>
-
+  </header>
 
   <main>
     <h1>[ DEN LILLE PAKKE ]</h1>
@@ -158,14 +32,7 @@
       </div>
       <div class="package-info">
         <h2>Indhold</h2>
-        <ul>
-          <li>1 × Yamaha DXR12 højtaler</li>
-          <li>1 × Yamaha DXS12 subwoofer</li>
-          <li>Bluetooth-receiver</li>
-          <li>Stativ(er)</li>
-          <li>Opsætningsguide</li>
-          <li>Diverse kabler</li>
-        </ul>
+        <ul id="features"></ul>
         <p><strong>Værdi:</strong> 15.000 kr.</p>
         <p class="price">Pris for udlejning: 500 kr.</p>
       </div>
@@ -202,6 +69,21 @@
   <div id="toast" role="status" aria-live="polite"></div>
 
   <script>
+    const features = [
+      "1 × Yamaha DXR12 højtaler",
+      "1 × Yamaha DXS12 subwoofer",
+      "Bluetooth-receiver",
+      "Stativ(er)",
+      "Opsætningsguide",
+      "Diverse kabler"
+    ];
+    const list = document.getElementById('features');
+    features.forEach(item => {
+      const li = document.createElement('li');
+      li.textContent = item;
+      list.appendChild(li);
+    });
+
     document.querySelectorAll('.copy-btn').forEach(btn => {
       btn.addEventListener('click', async () => {
         const text = btn.dataset.copy;

--- a/pakke2.html
+++ b/pakke2.html
@@ -1,1 +1,103 @@
+<!DOCTYPE html>
+<html lang="da">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Den Udvidet Pakke - [ LYDSTYRKEN ]</title>
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700;900&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="assets/css/pakke.css">
+</head>
+<body>
+  <header>
+    <div class="logo" onclick="window.location.href='index.html'">[ LYDSTYRKEN ]</div>
+    <nav aria-label="Hovednavigation">
+      <a href="index.html#pakker">[ PAKKER ]</a>
+      <a href="#">[ BYG SELV ]</a>
+      <a href="index.html#hvem">[ HVEM ER VI? ]</a>
+      <a href="index.html#kontakt">[ KONTAKT ]</a>
+      <button class="login-btn" id="loginBtn">[ LOG IND ]</button>
+    </nav>
+  </header>
 
+  <main>
+    <h1>[ DEN UDVIDET PAKKE ]</h1>
+    <div class="package-layout">
+      <div class="package-image">
+        <img src="assets/img/pakke-2.jpg" alt="Den Udvidet Pakke">
+        <p class="package-desc">
+          Perfekt til mellemstore events og mindre scener.
+          Leverer ekstra slagkraft og fleksibilitet uden at fylde for meget.
+        </p>
+      </div>
+      <div class="package-info">
+        <h2>Indhold</h2>
+        <ul id="features"></ul>
+        <p><strong>Værdi:</strong> 25.000 kr.</p>
+        <p class="price">Pris for udlejning: 1.000 kr.</p>
+      </div>
+    </div>
+
+    <section id="kontakt" style="margin-top:28px">
+      <h2>[ KONTAKT ]</h2>
+      <div class="contact-list" aria-live="polite">
+        <div class="contact-row">
+          <div class="contact-emoji">📱</div>
+          <button class="copy-btn" data-copy="+45 42 60 34 70">[ +45 42 60 34 70 ]</button>
+        </div>
+        <div class="contact-row">
+          <div class="contact-emoji">📧</div>
+          <button class="copy-btn" data-copy="lydstyrken@gmail.com">[ lydstyrken@gmail.com ]</button>
+        </div>
+        <div class="contact-row">
+          <div class="contact-emoji">📷</div>
+          <button class="copy-btn" data-copy="@lydstyrken.pm">[ @lydstyrken.pm ]</button>
+        </div>
+        <div class="contact-row">
+          <div class="contact-emoji">📘</div>
+          <button class="copy-btn" data-copy="https://facebook.com/lydstyrken">[ facebook.com/lydstyrken ]</button>
+        </div>
+      </div>
+      <p class="muted" style="margin-top:10px">Tryk på en linje for at kopiere til udklipsholder.</p>
+    </section>
+  </main>
+
+  <footer>
+    &copy; 2025 [ LYDSTYRKEN ]. ALLE RETTIGHEDER FORBEHOLDES.
+  </footer>
+
+  <div id="toast" role="status" aria-live="polite"></div>
+
+  <script>
+    const features = [
+      "2 × Yamaha DXR12 højtalere",
+      "2 × Yamaha DXS15 subwoofere",
+      "4-kanals mixer",
+      "Bluetooth-receiver",
+      "Stativ(er)",
+      "Opsætningsguide",
+      "Diverse kabler"
+    ];
+    const list = document.getElementById('features');
+    features.forEach(item => {
+      const li = document.createElement('li');
+      li.textContent = item;
+      list.appendChild(li);
+    });
+
+    document.querySelectorAll('.copy-btn').forEach(btn => {
+      btn.addEventListener('click', async () => {
+        const text = btn.dataset.copy;
+        try {
+          await navigator.clipboard.writeText(text);
+          const toast = document.getElementById('toast');
+          toast.textContent = 'Kopieret: ' + text;
+          toast.style.opacity = '1';
+          setTimeout(() => toast.style.opacity = '0', 2000);
+        } catch {
+          alert('Kunne ikke kopiere. Kopiér manuelt: ' + text);
+        }
+      });
+    });
+  </script>
+</body>
+</html>

--- a/pakke3.html
+++ b/pakke3.html
@@ -1,1 +1,104 @@
+<!DOCTYPE html>
+<html lang="da">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Den Store Pakke - [ LYDSTYRKEN ]</title>
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700;900&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="assets/css/pakke.css">
+</head>
+<body>
+  <header>
+    <div class="logo" onclick="window.location.href='index.html'">[ LYDSTYRKEN ]</div>
+    <nav aria-label="Hovednavigation">
+      <a href="index.html#pakker">[ PAKKER ]</a>
+      <a href="#">[ BYG SELV ]</a>
+      <a href="index.html#hvem">[ HVEM ER VI? ]</a>
+      <a href="index.html#kontakt">[ KONTAKT ]</a>
+      <button class="login-btn" id="loginBtn">[ LOG IND ]</button>
+    </nav>
+  </header>
 
+  <main>
+    <h1>[ DEN STORE PAKKE ]</h1>
+    <div class="package-layout">
+      <div class="package-image">
+        <img src="assets/img/pakke-3.jpg" alt="Den Store Pakke">
+        <p class="package-desc">
+          Når du skal levere lyd til de helt store arrangementer.
+          Massivt tryk og topklasse klarhed til publikum på flere hundrede.
+        </p>
+      </div>
+      <div class="package-info">
+        <h2>Indhold</h2>
+        <ul id="features"></ul>
+        <p><strong>Værdi:</strong> 50.000 kr.</p>
+        <p class="price">Pris for udlejning: 2.000 kr.</p>
+      </div>
+    </div>
+
+    <section id="kontakt" style="margin-top:28px">
+      <h2>[ KONTAKT ]</h2>
+      <div class="contact-list" aria-live="polite">
+        <div class="contact-row">
+          <div class="contact-emoji">📱</div>
+          <button class="copy-btn" data-copy="+45 42 60 34 70">[ +45 42 60 34 70 ]</button>
+        </div>
+        <div class="contact-row">
+          <div class="contact-emoji">📧</div>
+          <button class="copy-btn" data-copy="lydstyrken@gmail.com">[ lydstyrken@gmail.com ]</button>
+        </div>
+        <div class="contact-row">
+          <div class="contact-emoji">📷</div>
+          <button class="copy-btn" data-copy="@lydstyrken.pm">[ @lydstyrken.pm ]</button>
+        </div>
+        <div class="contact-row">
+          <div class="contact-emoji">📘</div>
+          <button class="copy-btn" data-copy="https://facebook.com/lydstyrken">[ facebook.com/lydstyrken ]</button>
+        </div>
+      </div>
+      <p class="muted" style="margin-top:10px">Tryk på en linje for at kopiere til udklipsholder.</p>
+    </section>
+  </main>
+
+  <footer>
+    &copy; 2025 [ LYDSTYRKEN ]. ALLE RETTIGHEDER FORBEHOLDES.
+  </footer>
+
+  <div id="toast" role="status" aria-live="polite"></div>
+
+  <script>
+    const features = [
+      "4 × Yamaha DZR15 højtalere",
+      "4 × Yamaha DXS18 subwoofere",
+      "8-kanals mixer",
+      "2 × Mikrofon",
+      "Bluetooth-receiver",
+      "Stativ(er)",
+      "Opsætningsguide",
+      "Diverse kabler"
+    ];
+    const list = document.getElementById('features');
+    features.forEach(item => {
+      const li = document.createElement('li');
+      li.textContent = item;
+      list.appendChild(li);
+    });
+
+    document.querySelectorAll('.copy-btn').forEach(btn => {
+      btn.addEventListener('click', async () => {
+        const text = btn.dataset.copy;
+        try {
+          await navigator.clipboard.writeText(text);
+          const toast = document.getElementById('toast');
+          toast.textContent = 'Kopieret: ' + text;
+          toast.style.opacity = '1';
+          setTimeout(() => toast.style.opacity = '0', 2000);
+        } catch {
+          alert('Kunne ikke kopiere. Kopiér manuelt: ' + text);
+        }
+      });
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Extract shared package styles into `assets/css/pakke.css` with hover animation for feature lists
- Rewrite `pakke1.html` to use the shared stylesheet and generate its contents list from a simple array
- Add new `pakke2.html` and `pakke3.html` pages with matching layout and easily editable feature arrays

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acfbf26a30832bac08db947ca0536d