### PR TITLE
Add Firebase login and account management pages

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="da">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Admin - LYDSTYRKEN</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      background: #000;
+      color: #fff;
+      margin: 0;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+    }
+    .container {
+      background: #111;
+      padding: 20px;
+      border-radius: 10px;
+      width: 90%;
+      max-width: 700px;
+    }
+    h1 { color: #00ff66; }
+    ul { list-style: none; padding: 0; }
+    li { margin-bottom: 15px; }
+    button {
+      padding: 5px 10px;
+      background: #ff4444;
+      border: none;
+      color: #fff;
+      border-radius: 4px;
+      cursor: pointer;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Admin panel</h1>
+    <ul id="userList"></ul>
+    <button id="logoutBtn">Log ud</button>
+  </div>
+  <script type="module">
+    import { initializeApp } from "https://www.gstatic.com/firebasejs/10.14.1/firebase-app.js";
+    import { getAuth, onAuthStateChanged, signOut } from "https://www.gstatic.com/firebasejs/10.14.1/firebase-auth.js";
+    import { getFirestore, collection, getDocs, doc, deleteDoc, getDoc } from "https://www.gstatic.com/firebasejs/10.14.1/firebase-firestore.js";
+
+    const firebaseConfig = {
+      apiKey: "AIzaSyCyKtFD4BrFjKGtPGy2cKPenkysz4h2lLI",
+      authDomain: "lydstyrken-ab288.firebaseapp.com",
+      projectId: "lydstyrken-ab288",
+      storageBucket: "lydstyrken-ab288.appspot.com",
+      messagingSenderId: "140962566931",
+      appId: "1:140962566931:web:b7f4ababaf3184bc8cc0e6",
+      measurementId: "G-Q74KMFN9YV"
+    };
+
+    const app = initializeApp(firebaseConfig);
+    const auth = getAuth(app);
+    const db = getFirestore(app);
+
+    onAuthStateChanged(auth, async (user) => {
+      if (!user || user.email !== "lydstyrken.admin") {
+        window.location.href = "index.html";
+        return;
+      }
+      const snap = await getDocs(collection(db, "users"));
+      const list = document.getElementById("userList");
+      for (const docSnap of snap.docs) {
+        const data = docSnap.data();
+        const li = document.createElement("li");
+        li.innerHTML = `<strong>${data.email}</strong> - nyhedsbrev: ${data.newsletter ? "ja" : "nej"} <button data-id="${docSnap.id}">Slet</button><ul id="orders-${docSnap.id}"></ul>`;
+        list.appendChild(li);
+        const ordersSnap = await getDocs(collection(db, "users", docSnap.id, "orders"));
+        const ordersUl = document.getElementById(`orders-${docSnap.id}`);
+        ordersSnap.forEach((o) => {
+          const orderLi = document.createElement("li");
+          orderLi.textContent = `${o.id} - ${o.data().item || ""}`;
+          ordersUl.appendChild(orderLi);
+        });
+        li.querySelector("button").addEventListener("click", async (e) => {
+          await deleteDoc(doc(db, "users", e.target.dataset.id));
+          li.remove();
+        });
+      }
+    });
+
+    document.getElementById("logoutBtn").addEventListener("click", () => {
+      signOut(auth).then(() => {
+        localStorage.removeItem("lydstyrkenUser");
+        window.location.href = "index.html";
+      });
+    });
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -287,8 +287,7 @@
         <div class="user-menu" style="display:none;">
         <div class="user-name" id="user-name"></div>
         <div class="dropdown-menu">
-            <a href="min-konto.html">[ Min konto ]</a>
-            <a href="tidligere-ordrer.html">[ Tidligere ordrer ]</a>
+            <a href="konto.html">[ Min konto ]</a>
             <a href="#" onclick="logout()">[ Log ud ]</a>
         </div>
         </div>

--- a/konto.html
+++ b/konto.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="da">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Min konto - LYDSTYRKEN</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      background-color: #000;
+      color: #fff;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      height: 100vh;
+      margin: 0;
+    }
+    .container {
+      background: #111;
+      padding: 20px;
+      border-radius: 10px;
+      width: 90%;
+      max-width: 500px;
+    }
+    h1 { color: #00ff66; }
+    label { display: block; margin: 15px 0; }
+    button {
+      padding: 10px 15px;
+      border: none;
+      border-radius: 5px;
+      background: #00ff66;
+      color: #000;
+      font-weight: bold;
+      cursor: pointer;
+    }
+    button:hover { background: #00cc52; }
+    ul { padding-left: 20px; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Min konto</h1>
+    <p>Email: <span id="userEmail"></span></p>
+    <label><input type="checkbox" id="newsletter" /> Tilmeld nyhedsbrev</label>
+    <h2>Tidligere ordrer</h2>
+    <ul id="orders"></ul>
+    <button id="logoutBtn">Log ud</button>
+  </div>
+  <script type="module">
+    import { initializeApp } from "https://www.gstatic.com/firebasejs/10.14.1/firebase-app.js";
+    import { getAuth, onAuthStateChanged, signOut } from "https://www.gstatic.com/firebasejs/10.14.1/firebase-auth.js";
+    import { getFirestore, doc, getDoc, updateDoc, collection, getDocs } from "https://www.gstatic.com/firebasejs/10.14.1/firebase-firestore.js";
+
+    const firebaseConfig = {
+      apiKey: "AIzaSyCyKtFD4BrFjKGtPGy2cKPenkysz4h2lLI",
+      authDomain: "lydstyrken-ab288.firebaseapp.com",
+      projectId: "lydstyrken-ab288",
+      storageBucket: "lydstyrken-ab288.appspot.com",
+      messagingSenderId: "140962566931",
+      appId: "1:140962566931:web:b7f4ababaf3184bc8cc0e6",
+      measurementId: "G-Q74KMFN9YV"
+    };
+
+    const app = initializeApp(firebaseConfig);
+    const auth = getAuth(app);
+    const db = getFirestore(app);
+
+    onAuthStateChanged(auth, async (user) => {
+      if (!user) {
+        window.location.href = "login.html";
+        return;
+      }
+      document.getElementById("userEmail").textContent = user.email;
+      const userRef = doc(db, "users", user.uid);
+      const snap = await getDoc(userRef);
+      if (snap.exists()) {
+        document.getElementById("newsletter").checked = snap.data().newsletter === true;
+      }
+      const ordersSnap = await getDocs(collection(userRef, "orders"));
+      ordersSnap.forEach((o) => {
+        const li = document.createElement("li");
+        li.textContent = `${o.id} - ${o.data().item || ""}`;
+        document.getElementById("orders").appendChild(li);
+      });
+      document.getElementById("newsletter").addEventListener("change", async (e) => {
+        await updateDoc(userRef, { newsletter: e.target.checked });
+      });
+    });
+
+    document.getElementById("logoutBtn").addEventListener("click", () => {
+      signOut(auth).then(() => {
+        localStorage.removeItem("lydstyrkenUser");
+        window.location.href = "index.html";
+      });
+    });
+  </script>
+</body>
+</html>

--- a/login.html
+++ b/login.html
@@ -82,8 +82,10 @@
   <script type="module">
     // Import Firebase
     import { initializeApp } from "https://www.gstatic.com/firebasejs/10.14.1/firebase-app.js";
-    import { getAuth, signInWithEmailAndPassword, createUserWithEmailAndPassword, GoogleAuthProvider, signInWithPopup } 
+    import { getAuth, signInWithEmailAndPassword, createUserWithEmailAndPassword, GoogleAuthProvider, signInWithPopup }
       from "https://www.gstatic.com/firebasejs/10.14.1/firebase-auth.js";
+    import { getFirestore, doc, setDoc, getDoc }
+      from "https://www.gstatic.com/firebasejs/10.14.1/firebase-firestore.js";
 
     // Firebase config
     const firebaseConfig = {
@@ -99,17 +101,27 @@
     // Init Firebase
     const app = initializeApp(firebaseConfig);
     const auth = getAuth(app);
+    const db = getFirestore(app);
+
+    async function ensureUserDoc(user){
+      const ref = doc(db, "users", user.uid);
+      const snap = await getDoc(ref);
+      if(!snap.exists()){
+        await setDoc(ref, { email: user.email, newsletter: false });
+      }
+    }
 
     // Email login
     window.login = function() {
       const email = document.getElementById("email").value;
       const password = document.getElementById("password").value;
       signInWithEmailAndPassword(auth, email, password)
-        .then((userCredential) => {
+        .then(async (userCredential) => {
           const user = userCredential.user;
+          await ensureUserDoc(user);
           localStorage.setItem("lydstyrkenUser", user.email);
-          alert("Logget ind som: " + user.email);
-          window.location.href = "index.html";
+          const dest = user.email === "lydstyrken.admin" ? "admin.html" : "konto.html";
+          window.location.href = dest;
         })
         .catch((error) => {
           alert("Fejl: " + error.message);
@@ -121,11 +133,11 @@
       const email = document.getElementById("email").value;
       const password = document.getElementById("password").value;
       createUserWithEmailAndPassword(auth, email, password)
-        .then((userCredential) => {
+        .then(async (userCredential) => {
           const user = userCredential.user;
+          await ensureUserDoc(user);
           localStorage.setItem("lydstyrkenUser", user.email);
-          alert("Bruger oprettet: " + user.email);
-          window.location.href = "index.html";
+          window.location.href = "konto.html";
         })
         .catch((error) => {
           alert("Fejl: " + error.message);
@@ -136,11 +148,12 @@
     window.googleLogin = function() {
       const provider = new GoogleAuthProvider();
       signInWithPopup(auth, provider)
-        .then((result) => {
+        .then(async (result) => {
           const user = result.user;
+          await ensureUserDoc(user);
           localStorage.setItem("lydstyrkenUser", user.displayName || user.email);
-          alert("Logget ind som: " + (user.displayName || user.email));
-          window.location.href = "index.html";
+          const dest = user.email === "lydstyrken.admin" ? "admin.html" : "konto.html";
+          window.location.href = dest;
         })
         .catch((error) => {
           alert("Fejl: " + error.message);


### PR DESCRIPTION
## Summary
- integrate Firestore user creation and redirect logic in login flow
- add user account page with newsletter toggle and order listing
- add admin panel to inspect users and their orders
- update site navigation to link to account page

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae4181c778832bae876be76488a22b