### PR TITLE
Add account dropdown and redirect to current page after login

### DIFF
--- a/assets/css/pakke.css
+++ b/assets/css/pakke.css
@@ -44,6 +44,12 @@ nav a:active{transform:translateY(0);box-shadow:none}
 }
 .login-btn:active{transform:translateY(1px)}
 
+.user-menu{position:relative;display:none}
+.user-menu .dropdown-menu{display:none;position:absolute;top:110%;right:0;background:#111;border:1px solid #444;border-radius:4px}
+.user-menu:hover .dropdown-menu{display:block}
+.dropdown-menu a{display:block;padding:10px;color:#fff;text-decoration:none}
+.dropdown-menu a:hover{background:var(--green);color:#000}
+
 main{max-width:1100px;margin:40px auto;padding:0 18px}
 
 .package-layout{

--- a/assets/js/auth.js
+++ b/assets/js/auth.js
@@ -1,0 +1,46 @@
+import { initializeApp } from "https://www.gstatic.com/firebasejs/10.14.1/firebase-app.js";
+import { getAuth, onAuthStateChanged, signOut } from "https://www.gstatic.com/firebasejs/10.14.1/firebase-auth.js";
+
+const firebaseConfig = {
+  apiKey: "AIzaSyCyKtFD4BrFjKGtPGy2cKPenkysz4h2lLI",
+  authDomain: "lydstyrken-ab288.firebaseapp.com",
+  projectId: "lydstyrken-ab288",
+  storageBucket: "lydstyrken-ab288.appspot.com",
+  messagingSenderId: "140962566931",
+  appId: "1:140962566931:web:b7f4ababaf3184bc8cc0e6",
+  measurementId: "G-Q74KMFN9YV"
+};
+
+const app = initializeApp(firebaseConfig);
+const auth = getAuth(app);
+
+// store the page user came from
+const loginBtn = document.getElementById('loginBtn');
+if (loginBtn) {
+  loginBtn.addEventListener('click', () => {
+    localStorage.setItem('redirectAfterLogin', window.location.pathname + window.location.search + window.location.hash);
+    window.location.href = 'login.html';
+  });
+}
+
+const userMenu = document.getElementById('userMenu');
+onAuthStateChanged(auth, (user) => {
+  if (user) {
+    if (loginBtn) loginBtn.style.display = 'none';
+    if (userMenu) userMenu.style.display = 'inline-block';
+  } else {
+    if (loginBtn) loginBtn.style.display = 'inline-block';
+    if (userMenu) userMenu.style.display = 'none';
+  }
+});
+
+const logoutLink = document.getElementById('logoutLink');
+if (logoutLink) {
+  logoutLink.addEventListener('click', (e) => {
+    e.preventDefault();
+    signOut(auth).then(() => {
+      localStorage.removeItem('lydstyrkenUser');
+      window.location.href = 'index.html';
+    });
+  });
+}

--- a/index.html
+++ b/index.html
@@ -174,101 +174,11 @@
     opacity: 1;
     transform: translateY(0);
     }
-
-    /* old price-row rules removed - new styles defined above */
-
-        /* Brugermenu styling */
-    .user-menu {
-    position: relative;
-    display: none; /* Skjult som standard */
-    }
-
-    .user-name {
-    font-weight: bold;
-    color: #00ff66;
-    cursor: pointer;
-    padding: 6px 12px;
-    border: 1px solid #444;
-    border-radius: 4px;
-    }
-
-    .user-name:hover {
-    background: #00ff66;
-    color: black;
-    }
-
-    .dropdown {
-    display: none;
-    position: absolute;
-    top: 35px;
-    right: 0;
-    background: #111;
-    border: 1px solid #444;
-    border-radius: 4px;
-    overflow: hidden;
-    min-width: 160px;
-    z-index: 100;
-    }
-
-    .dropdown a {
-    display: block;
-    padding: 10px;
-    color: white;
-    text-decoration: none;
-    font-size: 14px;
-    }
-
-    .dropdown a:hover {
-    background: #00ff66;
-    color: black;
-    }
-
-    .user-menu:hover .dropdown {
-    display: block;
-    }
-
-    .user-menu {
-    position: relative;
-    display: inline-block;
-    cursor: pointer;
-    }
-
-    .user-name {
-    color: #4CAF50;
-    font-weight: bold;
-    padding: 8px 12px;
-    border: 2px solid #4CAF50;
-    border-radius: 4px;
-    }
-
-    .dropdown-menu {
-    display: none;
-    position: absolute;
-    top: 110%;
-    right: 0;
-    background: white;
-    border: 1px solid #ddd;
-    box-shadow: 0 4px 8px rgba(0,0,0,0.1);
-    min-width: 160px;
-    z-index: 1000;
-    }
-
-    .dropdown-menu a {
-    display: block;
-    padding: 10px;
-    color: black;
-    text-decoration: none;
-    }
-
-    .dropdown-menu a:hover {
-    background: #f0f0f0;
-    }
-
-    .user-menu:hover .dropdown-menu {
-    display: block;
-    }
-
-
+    .user-menu{position:relative;display:none}
+    .user-menu .dropdown-menu{display:none;position:absolute;top:110%;right:0;background:#111;border:1px solid #444;border-radius:4px}
+    .user-menu:hover .dropdown-menu{display:block}
+    .dropdown-menu a{display:block;padding:10px;color:#fff;text-decoration:none}
+    .dropdown-menu a:hover{background:var(--green);color:#000}
   </style>
 </head>
 <body>
@@ -279,50 +189,17 @@
       <a href="#bygselv">[ BYG SELV ]</a>
       <a href="#hvem">[ HVEM ER VI? ]</a>
       <a href="#kontakt">[ KONTAKT ]</a>
-      <!-- Login knap -->
-        <!-- Login-knap -->
-        <button class="login-btn" id="loginBtn">[ LOG IND ]</button>
-
-        <!-- Brugermenu -->
-        <div class="user-menu" style="display:none;">
-        <div class="user-name" id="user-name"></div>
+      <button class="login-btn" id="loginBtn">[ LOG IND ]</button>
+      <div class="user-menu" id="userMenu" style="display:none;">
+        <button class="login-btn">[ MIN KONTO ]</button>
         <div class="dropdown-menu">
-            <a href="konto.html">[ Min konto ]</a>
-            <a href="#" onclick="logout()">[ Log ud ]</a>
+          <a href="tidligere-ordre.html">[ Tidligere ordre ]</a>
+          <a href="indstillinger.html">[ Indstillinger ]</a>
+          <a href="#" id="logoutLink">[ Log ud ]</a>
         </div>
-        </div>
-
-
+      </div>
     </nav>
 
-    <div id="userDisplay" style="position: absolute; top: 10px; right: 20px; color: #00ff66; font-weight: bold;"></div>
-        <script>
-        const user = localStorage.getItem("lydstyrkenUser");
-        if (user) {
-            document.getElementById("userDisplay").textContent = "Hej, " + user;
-        }
-        </script>
-
-        <div id="userArea" style="position: absolute; top: 10px; right: 20px; color: #00ff66; font-weight: bold; display: flex; gap: 10px; align-items: center;"></div>
-
-        <script>
-        const user = localStorage.getItem("lydstyrkenUser");
-        const userArea = document.getElementById("userArea");
-
-        if (user) {
-            userArea.innerHTML = `
-            <span>Hej, ${user}</span>
-            <button onclick="window.location.href='konto.html'" style="background: transparent; border: 2px solid #00ff66; color: #00ff66; padding: 5px 10px; border-radius: 5px; cursor: pointer;">Min konto</button>
-            <button onclick="logout()" style="background: transparent; border: 2px solid #ff4444; color: #ff4444; padding: 5px 10px; border-radius: 5px; cursor: pointer;">Log ud</button>
-            `;
-        }
-
-        function logout() {
-            localStorage.removeItem("lydstyrkenUser");
-            alert("Du er nu logget ud");
-            window.location.href = "index.html";
-        }
-        </script>
 
   </header>
 
@@ -462,13 +339,6 @@
         });
       });
 
-      // login button placeholder
-      const loginBtn = document.getElementById('loginBtn');
-      loginBtn.addEventListener('click', function () {
-        // replace with real login flow later
-        window.location.href = '/login';
-      });
-
       // modal actions
       document.getElementById('modalClose').addEventListener('click', function () {
         hideFallbackModal();
@@ -543,39 +413,6 @@
 
   </script>
 
-    <script>
-
-    import { getAuth, signOut } from "https://www.gstatic.com/firebasejs/10.14.1/firebase-auth.js";
-
-    const auth = getAuth();
-
-    const loginBtn = document.getElementById("loginBtn");
-    const userMenu = document.querySelector(".user-menu");
-    const userNameSpan = document.getElementById("user-name");
-
-    auth.onAuthStateChanged((user) => {
-    if (user) {
-        // Skjul login knap
-        loginBtn.style.display = "none";
-
-        // Vis brugermenu
-        userMenu.style.display = "inline-block";
-
-        // Sæt brugernavn (eller email hvis der ikke er navn)
-        userNameSpan.textContent = user.displayName || user.email;
-    } else {
-        // Vis login knap
-        loginBtn.style.display = "inline-block";
-        userMenu.style.display = "none";
-    }
-    });
-
-    // Log ud funktion
-    window.logout = function() {
-    signOut(auth).then(() => {
-        window.location.href = "index.html";
-    });
-    };
-
+  <script type="module" src="assets/js/auth.js"></script>
 </body>
 </html>

--- a/indstillinger.html
+++ b/indstillinger.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="da">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Indstillinger - [ LYDSTYRKEN ]</title>
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700;900&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="assets/css/pakke.css">
+</head>
+<body>
+  <header>
+    <div class="logo" onclick="window.location.href='index.html'">[ LYDSTYRKEN ]</div>
+    <nav aria-label="Hovednavigation">
+      <a href="index.html#pakker">[ PAKKER ]</a>
+      <a href="#">[ BYG SELV ]</a>
+      <a href="index.html#hvem">[ HVEM ER VI? ]</a>
+      <a href="index.html#kontakt">[ KONTAKT ]</a>
+      <button class="login-btn" id="loginBtn">[ LOG IND ]</button>
+      <div class="user-menu" id="userMenu" style="display:none;">
+        <button class="login-btn">[ MIN KONTO ]</button>
+        <div class="dropdown-menu">
+          <a href="tidligere-ordre.html">[ Tidligere ordre ]</a>
+          <a href="indstillinger.html">[ Indstillinger ]</a>
+          <a href="#" id="logoutLink">[ Log ud ]</a>
+        </div>
+      </div>
+    </nav>
+  </header>
+
+  <main>
+    <h1>[ INDSTILLINGER ]</h1>
+    <p>Tilpas dine kontooplysninger her.</p>
+  </main>
+
+  <script type="module" src="assets/js/auth.js"></script>
+</body>
+</html>

--- a/login.html
+++ b/login.html
@@ -129,7 +129,9 @@
           const user = userCredential.user;
           await ensureUserDoc(user);
           localStorage.setItem("lydstyrkenUser", user.email);
-          const dest = user.email === "lydstyrken.admin" ? "admin.html" : "konto.html";
+          const redirect = localStorage.getItem("redirectAfterLogin") || "index.html";
+          localStorage.removeItem("redirectAfterLogin");
+          const dest = user.email === "lydstyrken.admin" ? "admin.html" : redirect;
           window.location.href = dest;
         })
         .catch((error) => {
@@ -146,7 +148,9 @@
           const user = userCredential.user;
           await ensureUserDoc(user);
           localStorage.setItem("lydstyrkenUser", user.email);
-          window.location.href = "konto.html";
+          const redirect = localStorage.getItem("redirectAfterLogin") || "index.html";
+          localStorage.removeItem("redirectAfterLogin");
+          window.location.href = redirect;
         })
         .catch((error) => {
           alert("Fejl: " + error.message);
@@ -161,7 +165,9 @@
           const user = result.user;
           await ensureUserDoc(user);
           localStorage.setItem("lydstyrkenUser", user.displayName || user.email);
-          const dest = user.email === "lydstyrken.admin" ? "admin.html" : "konto.html";
+          const redirect = localStorage.getItem("redirectAfterLogin") || "index.html";
+          localStorage.removeItem("redirectAfterLogin");
+          const dest = user.email === "lydstyrken.admin" ? "admin.html" : redirect;
           window.location.href = dest;
         })
         .catch((error) => {

--- a/pakke1.html
+++ b/pakke1.html
@@ -16,6 +16,14 @@
       <a href="index.html#hvem">[ HVEM ER VI? ]</a>
       <a href="index.html#kontakt">[ KONTAKT ]</a>
       <button class="login-btn" id="loginBtn">[ LOG IND ]</button>
+      <div class="user-menu" id="userMenu" style="display:none;">
+        <button class="login-btn">[ MIN KONTO ]</button>
+        <div class="dropdown-menu">
+          <a href="tidligere-ordre.html">[ Tidligere ordre ]</a>
+          <a href="indstillinger.html">[ Indstillinger ]</a>
+          <a href="#" id="logoutLink">[ Log ud ]</a>
+        </div>
+      </div>
     </nav>
   </header>
 
@@ -100,5 +108,6 @@
       });
     });
   </script>
+  <script type="module" src="assets/js/auth.js"></script>
 </body>
 </html>

--- a/pakke2.html
+++ b/pakke2.html
@@ -16,6 +16,14 @@
       <a href="index.html#hvem">[ HVEM ER VI? ]</a>
       <a href="index.html#kontakt">[ KONTAKT ]</a>
       <button class="login-btn" id="loginBtn">[ LOG IND ]</button>
+      <div class="user-menu" id="userMenu" style="display:none;">
+        <button class="login-btn">[ MIN KONTO ]</button>
+        <div class="dropdown-menu">
+          <a href="tidligere-ordre.html">[ Tidligere ordre ]</a>
+          <a href="indstillinger.html">[ Indstillinger ]</a>
+          <a href="#" id="logoutLink">[ Log ud ]</a>
+        </div>
+      </div>
     </nav>
   </header>
 
@@ -99,5 +107,6 @@
       });
     });
   </script>
+  <script type="module" src="assets/js/auth.js"></script>
 </body>
 </html>

--- a/pakke3.html
+++ b/pakke3.html
@@ -16,6 +16,14 @@
       <a href="index.html#hvem">[ HVEM ER VI? ]</a>
       <a href="index.html#kontakt">[ KONTAKT ]</a>
       <button class="login-btn" id="loginBtn">[ LOG IND ]</button>
+      <div class="user-menu" id="userMenu" style="display:none;">
+        <button class="login-btn">[ MIN KONTO ]</button>
+        <div class="dropdown-menu">
+          <a href="tidligere-ordre.html">[ Tidligere ordre ]</a>
+          <a href="indstillinger.html">[ Indstillinger ]</a>
+          <a href="#" id="logoutLink">[ Log ud ]</a>
+        </div>
+      </div>
     </nav>
   </header>
 
@@ -100,5 +108,6 @@
       });
     });
   </script>
+  <script type="module" src="assets/js/auth.js"></script>
 </body>
 </html>

--- a/tidligere-ordre.html
+++ b/tidligere-ordre.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="da">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tidligere ordre - [ LYDSTYRKEN ]</title>
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700;900&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="assets/css/pakke.css">
+</head>
+<body>
+  <header>
+    <div class="logo" onclick="window.location.href='index.html'">[ LYDSTYRKEN ]</div>
+    <nav aria-label="Hovednavigation">
+      <a href="index.html#pakker">[ PAKKER ]</a>
+      <a href="#">[ BYG SELV ]</a>
+      <a href="index.html#hvem">[ HVEM ER VI? ]</a>
+      <a href="index.html#kontakt">[ KONTAKT ]</a>
+      <button class="login-btn" id="loginBtn">[ LOG IND ]</button>
+      <div class="user-menu" id="userMenu" style="display:none;">
+        <button class="login-btn">[ MIN KONTO ]</button>
+        <div class="dropdown-menu">
+          <a href="tidligere-ordre.html">[ Tidligere ordre ]</a>
+          <a href="indstillinger.html">[ Indstillinger ]</a>
+          <a href="#" id="logoutLink">[ Log ud ]</a>
+        </div>
+      </div>
+    </nav>
+  </header>
+
+  <main>
+    <h1>[ TIDLIGERE ORDRE ]</h1>
+    <p>Her kan du se dine tidligere bestillinger.</p>
+  </main>
+
+  <script type="module" src="assets/js/auth.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Replace login button with **MIN KONTO** dropdown linking to previous orders, settings, and logout.
- Remember the page a visitor was on and send them back after authenticating.
- Introduce shared auth script and add placeholder pages for previous orders and settings.

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae5885949c832b90b62e7859a659da