### PR TITLE
Refactor account menu into dedicated page

### DIFF
--- a/assets/css/pakke.css
+++ b/assets/css/pakke.css
@@ -44,24 +44,7 @@ nav a:active{transform:translateY(0);box-shadow:none}
 }
 .login-btn:active{transform:translateY(1px)}
 
-.user-menu{position:relative;display:none}
-/* clickable top link uses nav a styles */
-.user-menu> a{display:inline-block}
-.user-menu .dropdown-menu{
-  position:absolute;top:110%;right:0;min-width:160px;
-  background:#111;border:1px solid #444;border-radius:6px;
-  display:flex;flex-direction:column;overflow:hidden;
-  opacity:0;transform:translateY(-8px);pointer-events:none;
-  box-shadow:0 4px 10px rgba(0,0,0,0.4);
-  transition:opacity .2s ease,transform .2s ease;
-}
-.user-menu:hover .dropdown-menu{opacity:1;transform:translateY(0);pointer-events:auto}
-.dropdown-menu a{
-  display:block;padding:10px 16px;color:#fff;text-decoration:none;
-  border:0;border-radius:0;white-space:nowrap;
-  transition:background .2s ease,color .2s ease;
-}
-.dropdown-menu a:hover{background:var(--green);color:#000}
+
 
 main{max-width:1100px;margin:40px auto;padding:0 18px}
 
@@ -113,5 +96,14 @@ main{max-width:1100px;margin:40px auto;padding:0 18px}
 .muted{color:var(--muted);font-weight:400;font-size:0.9rem}
 footer{padding:30px 18px;text-align:center;color:rgba(255,255,255,0.6);font-size:0.8rem}
 #toast{position:fixed;left:50%;transform:translateX(-50%);bottom:22px;background:#111;padding:10px 16px;border-radius:10px;border:1px solid rgba(255,255,255,0.06);opacity:0;pointer-events:none;transition:opacity .25s ease;z-index:60}
+
+.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:14px}
+.card{position:relative;border-radius:10px;overflow:hidden;aspect-ratio:1/1;border:1px solid rgba(255,255,255,0.03);cursor:pointer;transition:box-shadow .18s ease,transform .18s ease}
+.card:hover{box-shadow:0 6px 18px var(--accent);transform:translateY(-3px)}
+.card .overlay{position:absolute;inset:0;display:flex;flex-direction:column;justify-content:center;align-items:center;padding:14px;text-align:center;background:linear-gradient(to top,rgba(0,0,0,0.7),rgba(0,0,0,0));transition:background .3s ease}
+.card:hover .overlay{background:linear-gradient(to top,rgba(0,0,0,0.8),rgba(0,0,0,0.2))}
+.card h3{margin:0;font-size:1rem;font-weight:700}
+.option-icon{font-size:2.5rem;margin-bottom:8px}
+.card p{margin:6px 0 0;font-size:0.8rem;color:var(--muted);text-transform:none}
 
 @media (max-width:768px){.package-layout{grid-template-columns:1fr}}

--- a/assets/js/auth.js
+++ b/assets/js/auth.js
@@ -23,14 +23,15 @@ if (loginBtn) {
   });
 }
 
-const userMenu = document.getElementById('userMenu');
+// show account link when authenticated
+const accountLink = document.getElementById('accountLink');
 onAuthStateChanged(auth, (user) => {
   if (user) {
     if (loginBtn) loginBtn.style.display = 'none';
-    if (userMenu) userMenu.style.display = 'inline-block';
+    if (accountLink) accountLink.style.display = 'inline-block';
   } else {
     if (loginBtn) loginBtn.style.display = 'inline-block';
-    if (userMenu) userMenu.style.display = 'none';
+    if (accountLink) accountLink.style.display = 'none';
   }
 });
 

--- a/index.html
+++ b/index.html
@@ -174,23 +174,7 @@
     opacity: 1;
     transform: translateY(0);
     }
-    .user-menu{position:relative;display:none}
-    .user-menu> a{display:inline-block}
-    .user-menu .dropdown-menu{
-      position:absolute;top:110%;right:0;min-width:160px;
-      background:#111;border:1px solid #444;border-radius:6px;
-      display:flex;flex-direction:column;overflow:hidden;
-      opacity:0;transform:translateY(-8px);pointer-events:none;
-      box-shadow:0 4px 10px rgba(0,0,0,0.4);
-      transition:opacity .2s ease,transform .2s ease;
-    }
-    .user-menu:hover .dropdown-menu{opacity:1;transform:translateY(0);pointer-events:auto}
-    .dropdown-menu a{
-      display:block;padding:10px 16px;color:#fff;text-decoration:none;
-      border:0;border-radius:0;white-space:nowrap;
-      transition:background .2s ease,color .2s ease;
-    }
-    .dropdown-menu a:hover{background:var(--green);color:#000}
+    
   </style>
 </head>
 <body>
@@ -202,16 +186,7 @@
       <a href="#hvem">[ HVEM ER VI? ]</a>
       <a href="#kontakt">[ KONTAKT ]</a>
       <button class="login-btn" id="loginBtn">[ LOG IND ]</button>
-      <div class="user-menu" id="userMenu" style="display:none;">
-        <a href="konto.html" class="account-btn">MIN KONTO</a>
-        <div class="dropdown-menu">
-          <a href="konto.html">Profil</a>
-          <a href="tidligere-ordre.html">Tidligere ordre</a>
-          <a href="indstillinger.html">Indstillinger</a>
-          <a href="support.html">Support</a>
-          <a href="#" id="logoutLink">Log ud</a>
-        </div>
-      </div>
+      <a href="konto.html" id="accountLink" style="display:none;">[ MIN KONTO ]</a>
     </nav>
 
 

--- a/indstillinger.html
+++ b/indstillinger.html
@@ -16,16 +16,7 @@
       <a href="index.html#hvem">[ HVEM ER VI? ]</a>
       <a href="index.html#kontakt">[ KONTAKT ]</a>
       <button class="login-btn" id="loginBtn">[ LOG IND ]</button>
-      <div class="user-menu" id="userMenu" style="display:none;">
-        <a href="konto.html" class="account-btn">MIN KONTO</a>
-        <div class="dropdown-menu">
-          <a href="konto.html">Profil</a>
-          <a href="tidligere-ordre.html">Tidligere ordre</a>
-          <a href="indstillinger.html">Indstillinger</a>
-          <a href="support.html">Support</a>
-          <a href="#" id="logoutLink">Log ud</a>
-        </div>
-      </div>
+      <a href="konto.html" id="accountLink" style="display:none;">[ MIN KONTO ]</a>
     </nav>
   </header>
 

--- a/konto.html
+++ b/konto.html
@@ -6,6 +6,14 @@
   <title>Min konto - [ LYDSTYRKEN ]</title>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="assets/css/pakke.css">
+  <style>
+    .option.profile{background:linear-gradient(135deg,#1a1a1a,#004d26)}
+    .option.orders{background:linear-gradient(135deg,#1a1a1a,#00264d)}
+    .option.settings{background:linear-gradient(135deg,#1a1a1a,#4d2600)}
+    .option.support{background:linear-gradient(135deg,#1a1a1a,#4d004d)}
+    .option.logout{background:linear-gradient(135deg,#1a1a1a,#333)}
+    .card.option:hover{box-shadow:0 0 20px var(--green);}
+  </style>
 </head>
 <body>
   <header>
@@ -16,27 +24,48 @@
       <a href="index.html#hvem">[ HVEM ER VI? ]</a>
       <a href="index.html#kontakt">[ KONTAKT ]</a>
       <button class="login-btn" id="loginBtn">[ LOG IND ]</button>
-      <div class="user-menu" id="userMenu" style="display:none;">
-        <a href="konto.html" class="account-btn">MIN KONTO</a>
-        <div class="dropdown-menu">
-          <a href="konto.html">Profil</a>
-          <a href="tidligere-ordre.html">Tidligere ordre</a>
-          <a href="indstillinger.html">Indstillinger</a>
-          <a href="support.html">Support</a>
-          <a href="#" id="logoutLink">Log ud</a>
-        </div>
-      </div>
+      <a href="konto.html" id="accountLink" style="display:none;">[ MIN KONTO ]</a>
     </nav>
   </header>
 
   <main>
-    <div class="account-card">
-      <h1>[ MIN KONTO ]</h1>
-      <p>Email: <span id="userEmail"></span></p>
-      <h2>[ TIDLIGERE ORDRE ]</h2>
-      <ul id="orders">
-        <li>Ingen ordrer endnu.</li>
-      </ul>
+    <h1 style="text-align:center;margin-top:40px;">[ MIN KONTO ]</h1>
+    <div class="grid">
+      <div class="card option profile" onclick="location.href='profil.html'">
+        <div class="overlay">
+          <div class="option-icon">👤</div>
+          <h3>[ PROFIL ]</h3>
+          <p>Se dine oplysninger</p>
+        </div>
+      </div>
+      <div class="card option orders" onclick="location.href='tidligere-ordre.html'">
+        <div class="overlay">
+          <div class="option-icon">🧾</div>
+          <h3>[ TIDLIGERE ORDRE ]</h3>
+          <p>Overblik over dine køb</p>
+        </div>
+      </div>
+      <div class="card option settings" onclick="location.href='indstillinger.html'">
+        <div class="overlay">
+          <div class="option-icon">⚙️</div>
+          <h3>[ INDSTILLINGER ]</h3>
+          <p>Tilpas din konto</p>
+        </div>
+      </div>
+      <div class="card option support" onclick="location.href='support.html'">
+        <div class="overlay">
+          <div class="option-icon">💬</div>
+          <h3>[ SUPPORT ]</h3>
+          <p>Få hjælp og svar</p>
+        </div>
+      </div>
+      <div class="card option logout" id="logoutLink">
+        <div class="overlay">
+          <div class="option-icon">🚪</div>
+          <h3>[ LOG UD ]</h3>
+          <p>Afslut sessionen</p>
+        </div>
+      </div>
     </div>
   </main>
 
@@ -51,21 +80,17 @@
       storageBucket: "lydstyrken-ab288.appspot.com",
       messagingSenderId: "140962566931",
       appId: "1:140962566931:web:b7f4ababaf3184bc8cc0e6",
-      measurementId: "G-Q74KMFN9YV"
+      measurementId: "G-Q74KMFN9YV",
     };
 
     const app = initializeApp(firebaseConfig);
     const auth = getAuth(app);
-
     onAuthStateChanged(auth, (user) => {
       if (!user) {
-        window.location.href = "login.html";
-      } else {
-        document.getElementById("userEmail").textContent = user.email;
+        window.location.href = 'login.html';
       }
     });
   </script>
   <script type="module" src="assets/js/auth.js"></script>
 </body>
 </html>
-

--- a/pakke1.html
+++ b/pakke1.html
@@ -16,16 +16,7 @@
       <a href="index.html#hvem">[ HVEM ER VI? ]</a>
       <a href="index.html#kontakt">[ KONTAKT ]</a>
       <button class="login-btn" id="loginBtn">[ LOG IND ]</button>
-      <div class="user-menu" id="userMenu" style="display:none;">
-        <a href="konto.html" class="account-btn">MIN KONTO</a>
-        <div class="dropdown-menu">
-          <a href="konto.html">Profil</a>
-          <a href="tidligere-ordre.html">Tidligere ordre</a>
-          <a href="indstillinger.html">Indstillinger</a>
-          <a href="support.html">Support</a>
-          <a href="#" id="logoutLink">Log ud</a>
-        </div>
-      </div>
+      <a href="konto.html" id="accountLink" style="display:none;">[ MIN KONTO ]</a>
     </nav>
   </header>
 

--- a/pakke2.html
+++ b/pakke2.html
@@ -16,16 +16,7 @@
       <a href="index.html#hvem">[ HVEM ER VI? ]</a>
       <a href="index.html#kontakt">[ KONTAKT ]</a>
       <button class="login-btn" id="loginBtn">[ LOG IND ]</button>
-      <div class="user-menu" id="userMenu" style="display:none;">
-        <a href="konto.html" class="account-btn">MIN KONTO</a>
-        <div class="dropdown-menu">
-          <a href="konto.html">Profil</a>
-          <a href="tidligere-ordre.html">Tidligere ordre</a>
-          <a href="indstillinger.html">Indstillinger</a>
-          <a href="support.html">Support</a>
-          <a href="#" id="logoutLink">Log ud</a>
-        </div>
-      </div>
+      <a href="konto.html" id="accountLink" style="display:none;">[ MIN KONTO ]</a>
     </nav>
   </header>
 

--- a/pakke3.html
+++ b/pakke3.html
@@ -16,16 +16,7 @@
       <a href="index.html#hvem">[ HVEM ER VI? ]</a>
       <a href="index.html#kontakt">[ KONTAKT ]</a>
       <button class="login-btn" id="loginBtn">[ LOG IND ]</button>
-      <div class="user-menu" id="userMenu" style="display:none;">
-        <a href="konto.html" class="account-btn">MIN KONTO</a>
-        <div class="dropdown-menu">
-          <a href="konto.html">Profil</a>
-          <a href="tidligere-ordre.html">Tidligere ordre</a>
-          <a href="indstillinger.html">Indstillinger</a>
-          <a href="support.html">Support</a>
-          <a href="#" id="logoutLink">Log ud</a>
-        </div>
-      </div>
+      <a href="konto.html" id="accountLink" style="display:none;">[ MIN KONTO ]</a>
     </nav>
   </header>
 

--- a/profil.html
+++ b/profil.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="da">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Profil - [ LYDSTYRKEN ]</title>
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700;900&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="assets/css/pakke.css">
+</head>
+<body>
+  <header>
+    <div class="logo" onclick="window.location.href='index.html'">[ LYDSTYRKEN ]</div>
+    <nav aria-label="Hovednavigation">
+      <a href="index.html#pakker">[ PAKKER ]</a>
+      <a href="#">[ BYG SELV ]</a>
+      <a href="index.html#hvem">[ HVEM ER VI? ]</a>
+      <a href="index.html#kontakt">[ KONTAKT ]</a>
+      <button class="login-btn" id="loginBtn">[ LOG IND ]</button>
+      <a href="konto.html" id="accountLink" style="display:none;">[ MIN KONTO ]</a>
+    </nav>
+  </header>
+
+  <main>
+    <div class="account-card">
+      <h1>[ PROFIL ]</h1>
+      <p>Email: <span id="userEmail"></span></p>
+    </div>
+  </main>
+
+  <script type="module">
+    import { initializeApp } from "https://www.gstatic.com/firebasejs/10.14.1/firebase-app.js";
+    import { getAuth, onAuthStateChanged } from "https://www.gstatic.com/firebasejs/10.14.1/firebase-auth.js";
+
+    const firebaseConfig = {
+      apiKey: "AIzaSyCyKtFD4BrFjKGtPGy2cKPenkysz4h2lLI",
+      authDomain: "lydstyrken-ab288.firebaseapp.com",
+      projectId: "lydstyrken-ab288",
+      storageBucket: "lydstyrken-ab288.appspot.com",
+      messagingSenderId: "140962566931",
+      appId: "1:140962566931:web:b7f4ababaf3184bc8cc0e6",
+      measurementId: "G-Q74KMFN9YV",
+    };
+
+    const app = initializeApp(firebaseConfig);
+    const auth = getAuth(app);
+
+    onAuthStateChanged(auth, (user) => {
+      if (!user) {
+        window.location.href = "login.html";
+      } else {
+        document.getElementById("userEmail").textContent = user.email;
+      }
+    });
+  </script>
+  <script type="module" src="assets/js/auth.js"></script>
+</body>
+</html>

--- a/support.html
+++ b/support.html
@@ -16,16 +16,7 @@
       <a href="index.html#hvem">[ HVEM ER VI? ]</a>
       <a href="index.html#kontakt">[ KONTAKT ]</a>
       <button class="login-btn" id="loginBtn">[ LOG IND ]</button>
-      <div class="user-menu" id="userMenu" style="display:none;">
-        <a href="konto.html" class="account-btn">MIN KONTO</a>
-        <div class="dropdown-menu">
-          <a href="konto.html">Profil</a>
-          <a href="tidligere-ordre.html">Tidligere ordre</a>
-          <a href="indstillinger.html">Indstillinger</a>
-          <a href="support.html">Support</a>
-          <a href="#" id="logoutLink">Log ud</a>
-        </div>
-      </div>
+      <a href="konto.html" id="accountLink" style="display:none;">[ MIN KONTO ]</a>
     </nav>
   </header>
 

--- a/tidligere-ordre.html
+++ b/tidligere-ordre.html
@@ -16,16 +16,7 @@
       <a href="index.html#hvem">[ HVEM ER VI? ]</a>
       <a href="index.html#kontakt">[ KONTAKT ]</a>
       <button class="login-btn" id="loginBtn">[ LOG IND ]</button>
-      <div class="user-menu" id="userMenu" style="display:none;">
-        <a href="konto.html" class="account-btn">MIN KONTO</a>
-        <div class="dropdown-menu">
-          <a href="konto.html">Profil</a>
-          <a href="tidligere-ordre.html">Tidligere ordre</a>
-          <a href="indstillinger.html">Indstillinger</a>
-          <a href="support.html">Support</a>
-          <a href="#" id="logoutLink">Log ud</a>
-        </div>
-      </div>
+      <a href="konto.html" id="accountLink" style="display:none;">[ MIN KONTO ]</a>
     </nav>
   </header>
 


### PR DESCRIPTION
## Summary
- Remove dropdown-based account menu and show `[ MIN KONTO ]` link after login
- Add dedicated account dashboard with animated cards for profile, orders, settings, support and logout
- Introduce standalone profile page and CSS utilities for card grid

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae671d195c832ba269557995a15774