### PR TITLE
feat: add coverage grid utility and basic planner

### DIFF
--- a/byg-selv.html
+++ b/byg-selv.html
@@ -29,7 +29,7 @@
     .ls-tabs{display:flex;gap:4px;margin-bottom:8px;}
     .ls-tabs button{flex:1;padding:6px;border:none;background:var(--ls-green-3);color:#fff;cursor:pointer;}
     .ls-product-list{list-style:none;padding:0;margin:0;}
-    .ls-product-list li{margin-bottom:4px;padding:4px;background:var(--ls-green-7);}
+    .ls-product-list li{margin-bottom:4px;padding:4px;background:var(--ls-green-7);cursor:pointer;}
     .ls-cart h3,.ls-products h3{margin-top:0;}
     .ls-legend{list-style:none;margin:8px 0 0;padding:0;display:grid;grid-template-columns:repeat(2,1fr);gap:4px;font-size:12px;}
     .ls-legend span{display:inline-block;width:20px;height:12px;margin-right:4px;vertical-align:middle;}
@@ -97,5 +97,88 @@
       </div>
     </aside>
   </div>
+  <script type="module">
+    import {PRODUCTS_SEED} from './PRODUCTS_SEED.js';
+    import {calcCoverageGrid} from './utils/coverageGrid.js';
+
+    const CELL_PX = 25; // 1m grid cell
+    const area = {w:20, h:20};
+    const canvas = document.getElementById('ls-canvas');
+    const ctx = canvas.getContext('2d');
+    canvas.width = area.w * CELL_PX;
+    canvas.height = area.h * CELL_PX;
+
+    const speakers = [];
+
+    function hexToRgba(hex, alpha){
+      const int = parseInt(hex.slice(1),16);
+      const r=(int>>16)&255, g=(int>>8)&255, b=int&255;
+      return `rgba(${r},${g},${b},${alpha})`;
+    }
+
+    function render(){
+      const grid = calcCoverageGrid({widthM:area.w,heightM:area.h,cellSizeM:1,speakers});
+      ctx.clearRect(0,0,canvas.width,canvas.height);
+      grid.data.forEach((row,y)=>{
+        row.forEach((cell,x)=>{
+          if(cell.color.alpha>0){
+            ctx.fillStyle = hexToRgba(cell.color.hex, cell.color.alpha);
+            ctx.fillRect(x*CELL_PX, y*CELL_PX, CELL_PX, CELL_PX);
+          }
+        });
+      });
+      // draw speakers
+      speakers.forEach(sp=>{
+        ctx.save();
+        ctx.translate(sp.x*CELL_PX, sp.y*CELL_PX);
+        ctx.rotate(sp.rotDeg*Math.PI/180);
+        ctx.fillStyle = '#000';
+        ctx.beginPath();
+        ctx.moveTo(0,0);
+        ctx.lineTo(-5,10);
+        ctx.lineTo(5,10);
+        ctx.closePath();
+        ctx.fill();
+        ctx.restore();
+      });
+    }
+
+    // Add speaker by clicking product
+    document.querySelectorAll('.ls-product-list li').forEach((li,idx)=>{
+      li.addEventListener('click', ()=>{
+        const prod = PRODUCTS_SEED[idx];
+        speakers.push({x:area.w/2,y:area.h/2,rotDeg:0,productId:prod.id});
+        render();
+      });
+    });
+
+    // dragging speakers
+    let dragIdx = null;
+    canvas.addEventListener('mousedown', e=>{
+      const x = e.offsetX / CELL_PX;
+      const y = e.offsetY / CELL_PX;
+      dragIdx = speakers.findIndex(sp=>Math.hypot(sp.x-x, sp.y-y) < 0.5);
+    });
+    canvas.addEventListener('mousemove', e=>{
+      if(dragIdx!==null){
+        speakers[dragIdx].x = e.offsetX / CELL_PX;
+        speakers[dragIdx].y = e.offsetY / CELL_PX;
+        render();
+      }
+    });
+    canvas.addEventListener('mouseup', ()=> dragIdx=null);
+    canvas.addEventListener('mouseleave', ()=> dragIdx=null);
+
+    // rotate via right-click
+    canvas.addEventListener('contextmenu', e=>{
+      e.preventDefault();
+      const x = e.offsetX / CELL_PX;
+      const y = e.offsetY / CELL_PX;
+      const sp = speakers.find(sp=>Math.hypot(sp.x-x, sp.y-y) < 0.5);
+      if(sp){ sp.rotDeg = (sp.rotDeg + 15) % 360; render(); }
+    });
+
+    render();
+  </script>
 </body>
 </html>

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import {getCoverageColor} from '../utils/coverageColor.js';
 import {dbSum, splAtPointFromSpeaker} from '../utils/spl.js';
+import {calcCoverageGrid} from '../utils/coverageGrid.js';
 import {PRODUCTS_SEED} from '../PRODUCTS_SEED.js';
 
 // test getCoverageColor
@@ -15,5 +16,11 @@ assert(Math.abs(sum - (90 + 10*Math.log10(2))) < 1e-6);
 const product = PRODUCTS_SEED[0];
 const spl = splAtPointFromSpeaker({x:2,y:0}, {x:0,y:0,rotDeg:0,productId:product.id}, product);
 assert(spl < product.coverage.refSPLdB);
+
+// test calcCoverageGrid returns grid with expected size and color
+const grid = calcCoverageGrid({widthM:2,heightM:1,cellSizeM:1,speakers:[{x:0,y:0,rotDeg:0,productId:product.id}]});
+assert.equal(grid.rows, 1);
+assert.equal(grid.cols, 2);
+assert.equal(grid.data[0][0].color.hex, '#0B6623');
 
 console.log('All utility tests passed');

--- a/utils/coverageGrid.js
+++ b/utils/coverageGrid.js
@@ -1,0 +1,36 @@
+import {dbSum, splAtPointFromSpeaker} from './spl.js';
+import {getCoverageColor} from './coverageColor.js';
+import {PRODUCTS_SEED} from '../PRODUCTS_SEED.js';
+
+/**
+ * Calculate coverage grid for a rectangular area.
+ * @param {Object} params
+ * @param {number} params.widthM - Width of the area in meters.
+ * @param {number} params.heightM - Height of the area in meters.
+ * @param {number} [params.cellSizeM=1] - Grid cell size in meters.
+ * @param {import('./spl.js').SpeakerInstance[]} params.speakers - Array of speakers.
+ * @param {import('../PRODUCTS_SEED.js').Product[]} [params.products=PRODUCTS_SEED]
+ * @param {number} [params.targetSPLdB=94]
+ */
+export function calcCoverageGrid({widthM, heightM, cellSizeM=1, speakers, products=PRODUCTS_SEED, targetSPLdB=94}){
+  const cols = Math.ceil(widthM / cellSizeM);
+  const rows = Math.ceil(heightM / cellSizeM);
+  const prodMap = new Map(products.map(p => [p.id, p]));
+  const data = [];
+  for (let r=0; r<rows; r++){
+    const row = [];
+    const y = (r+0.5)*cellSizeM;
+    for (let c=0; c<cols; c++){
+      const x = (c+0.5)*cellSizeM;
+      const splVals = speakers.map(s => {
+        const prod = prodMap.get(s.productId);
+        return prod ? splAtPointFromSpeaker({x, y}, s, prod) : -Infinity;
+      }).filter(v => v > -Infinity);
+      const spl = splVals.length ? dbSum(splVals) : -Infinity;
+      const color = spl > -Infinity ? getCoverageColor(spl, {targetSPLdB}) : {hex:'transparent',alpha:0,percent:0,paletteIndex:-1};
+      row.push({x, y, spl, color});
+    }
+    data.push(row);
+  }
+  return {rows, cols, cellSizeM, data};
+}

--- a/utils/coverageGrid.ts
+++ b/utils/coverageGrid.ts
@@ -1,0 +1,39 @@
+import {dbSum, splAtPointFromSpeaker, SpeakerInstance} from './spl';
+import {getCoverageColor} from './coverageColor';
+import {PRODUCTS_SEED, Product} from '../PRODUCTS_SEED';
+
+export interface CoverageCell {
+  x: number;
+  y: number;
+  spl: number;
+  color: ReturnType<typeof getCoverageColor> | {hex:string;alpha:number;percent:number;paletteIndex:number};
+}
+export interface CoverageGrid {
+  rows: number;
+  cols: number;
+  cellSizeM: number;
+  data: CoverageCell[][];
+}
+
+export function calcCoverageGrid({widthM, heightM, cellSizeM=1, speakers, products=PRODUCTS_SEED, targetSPLdB=94}:{widthM:number;heightM:number;cellSizeM?:number;speakers:SpeakerInstance[];products?:Product[];targetSPLdB?:number;}): CoverageGrid {
+  const cols = Math.ceil(widthM / cellSizeM);
+  const rows = Math.ceil(heightM / cellSizeM);
+  const prodMap = new Map(products.map(p => [p.id, p]));
+  const data: CoverageCell[][] = [];
+  for (let r=0; r<rows; r++){
+    const row: CoverageCell[] = [];
+    const y = (r+0.5)*cellSizeM;
+    for (let c=0; c<cols; c++){
+      const x = (c+0.5)*cellSizeM;
+      const splVals = speakers.map(s => {
+        const prod = prodMap.get(s.productId);
+        return prod ? splAtPointFromSpeaker({x, y}, s, prod) : -Infinity;
+      }).filter(v => v > -Infinity);
+      const spl = splVals.length ? dbSum(splVals) : -Infinity;
+      const color = spl > -Infinity ? getCoverageColor(spl, {targetSPLdB}) : {hex:'transparent',alpha:0,percent:0,paletteIndex:-1};
+      row.push({x, y, spl, color});
+    }
+    data.push(row);
+  }
+  return {rows, cols, cellSizeM, data};
+}


### PR DESCRIPTION
## Summary
- compute SPL-based heatmap using new `calcCoverageGrid`
- allow adding and dragging speakers with live coverage in `byg-selv.html`
- expand unit tests for coverage utilities

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b727d77dd0832b9eb4bced35bcbf30