### PR TITLE
Enhance BYG SELV page styling and speaker interaction

### DIFF
--- a/byg-selv.html
+++ b/byg-selv.html
@@ -4,8 +4,13 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Byg-selv Lydplanlægger</title>
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700;900&display=swap" rel="stylesheet">
   <style>
     :root{
+      --bg:#000;
+      --card:#111;
+      --accent:#00ff88;
+      --muted:rgba(255,255,255,0.75);
       --ls-green-1:#0B6623;
       --ls-green-2:#1E7A2E;
       --ls-green-3:#2FA84F;
@@ -14,33 +19,41 @@
       --ls-green-6:#A4E1A6;
       --ls-green-7:#CDECCB;
     }
-    html,body{margin:0;height:100%;font-family:Arial,sans-serif;}
+    html,body{
+      margin:0;height:100%;
+      font-family:Montserrat,system-ui,Arial,sans-serif;
+      background:var(--bg);color:#fff;
+      text-transform:uppercase;
+    }
     body{display:flex;flex-direction:column;}
-    .ls-topbar{display:flex;align-items:center;padding:8px 12px;background:var(--ls-green-1);color:#fff;gap:8px;font-size:14px;}
-    .ls-topbar input,.ls-topbar select,.ls-topbar button{margin-right:8px;}
+    .ls-topbar{display:flex;align-items:center;padding:8px 12px;background:var(--card);color:#fff;gap:8px;font-size:14px;}
+    .ls-topbar input,.ls-topbar select{margin-right:8px;background:#222;color:#fff;border:1px solid #333;padding:6px;border-radius:4px;}
+    .ls-topbar button{margin-right:8px;padding:6px 10px;border:none;border-radius:4px;background:var(--accent);color:#000;font-weight:700;cursor:pointer;}
     .ls-main{flex:1;display:flex;}
-    .ls-left{width:180px;background:var(--ls-green-6);padding:8px;font-size:14px;}
+    .ls-left{width:180px;background:var(--card);padding:8px;font-size:14px;}
     .ls-left ul{list-style:none;padding:0;margin:8px 0 0;}
-    .ls-left li{margin-bottom:4px;cursor:pointer;padding:4px;}
-    .ls-left li.active{background:var(--ls-green-7);}
+    .ls-left li{margin-bottom:4px;cursor:pointer;padding:4px;border-radius:4px;}
+    .ls-left li.active{background:var(--accent);color:#000;}
     .ls-dropdown{position:relative;}
-    .ls-dropdown-menu{display:none;position:absolute;left:0;top:100%;background:var(--ls-green-7);padding:0;margin:4px 0 0;list-style:none;z-index:10;}
-    .ls-dropdown-menu li{margin:0;}
+    .ls-dropdown-menu{display:none;position:absolute;left:0;top:100%;background:#222;padding:0;margin:4px 0 0;list-style:none;z-index:10;border-radius:4px;}
+    .ls-dropdown-menu li{margin:0;padding:4px 8px;}
     .ls-dropdown.open .ls-dropdown-menu{display:block;}
-    .ls-canvas-container{flex:1;position:relative;background:#fff;}
-    #ls-canvas{width:100%;height:100%;background-size:25px 25px;background-image:linear-gradient(0deg,var(--ls-green-7) 1px,transparent 1px),linear-gradient(90deg,var(--ls-green-7) 1px,transparent 1px);}
-    .ls-right{width:260px;background:var(--ls-green-6);display:flex;flex-direction:column;}
+    .ls-canvas-container{flex:1;position:relative;background:var(--bg);}
+    #ls-canvas{width:100%;height:100%;background-size:25px 25px;background-image:linear-gradient(0deg,rgba(255,255,255,0.05) 1px,transparent 1px),linear-gradient(90deg,rgba(255,255,255,0.05) 1px,transparent 1px);}
+    .ls-right{width:260px;background:var(--card);display:flex;flex-direction:column;}
     .ls-products,.ls-cart{padding:8px;flex:1;overflow:auto;font-size:14px;}
     .ls-tabs{display:flex;gap:4px;margin-bottom:8px;}
-    .ls-tabs button{flex:1;padding:6px;border:none;background:var(--ls-green-3);color:#fff;cursor:pointer;}
+    .ls-tabs button{flex:1;padding:6px;border:none;background:#222;color:#fff;cursor:pointer;border-radius:4px;}
+    .ls-tabs button.active{background:var(--accent);color:#000;}
     .ls-product-list{list-style:none;padding:0;margin:0;}
-    .ls-product-list li{margin-bottom:4px;padding:4px;background:var(--ls-green-7);cursor:pointer;}
+    .ls-product-list li{margin-bottom:4px;padding:4px;background:#222;color:#fff;cursor:pointer;border-radius:4px;}
+    .ls-product-list li:hover{background:#333;}
     .ls-cart h3,.ls-products h3{margin-top:0;}
     .ls-legend{list-style:none;margin:8px 0 0;padding:0;display:grid;grid-template-columns:repeat(2,1fr);gap:4px;font-size:12px;}
     .ls-legend span{display:inline-block;width:20px;height:12px;margin-right:4px;vertical-align:middle;}
     .ls-cta{padding:8px;display:flex;flex-direction:column;gap:8px;}
-    .ls-cta button{padding:10px;background:var(--ls-green-2);color:#fff;border:none;border-radius:4px;cursor:pointer;}
-    .ls-onboarding{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);background:#fff;color:#000;padding:12px;border:1px solid var(--ls-green-3);font-size:14px;}
+    .ls-cta button{padding:10px;background:var(--accent);color:#000;border:none;border-radius:4px;cursor:pointer;font-weight:700;}
+    .ls-onboarding{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);background:#111;color:#fff;padding:12px;border:1px solid var(--accent);font-size:14px;}
   </style>
 </head>
 <body>
@@ -116,6 +129,7 @@
     const ctx = canvas.getContext('2d');
     canvas.width = area.w * CELL_PX;
     canvas.height = area.h * CELL_PX;
+    canvas.style.cursor = 'default';
 
 const speakers = [];
 const shapes = [];
@@ -364,6 +378,14 @@ let dragShape = null;
         currentMeasurement = {start:{x,y}, end:{x,y}};
         return;
       }
+
+      const spIdx = speakers.findIndex(sp=>Math.hypot(sp.x-x, sp.y-y) < 0.5);
+      if(spIdx !== -1){
+        dragIdx = spIdx;
+        canvas.style.cursor = 'grabbing';
+        return;
+      }
+
       for(let i=shapes.length-1;i>=0;i--){
         const sh = shapes[i];
         let hit = null;
@@ -398,8 +420,6 @@ let dragShape = null;
         }else{
           currentPolygon.push({x,y});
         }
-      }else{
-        dragIdx = speakers.findIndex(sp=>Math.hypot(sp.x-x, sp.y-y) < 0.5);
       }
     });
 
@@ -463,6 +483,7 @@ let dragShape = null;
       }else if(dragIdx!==null){
         speakers[dragIdx].x = x;
         speakers[dragIdx].y = y;
+        canvas.style.cursor = 'grabbing';
         render();
       }else{
         let found = null;
@@ -477,6 +498,8 @@ let dragShape = null;
           hoverShapeIdx = found;
           render();
         }
+        const overSp = speakers.findIndex(sp=>Math.hypot(sp.x-x, sp.y-y) < 0.5);
+        canvas.style.cursor = overSp !== -1 ? 'move' : 'default';
       }
     });
 
@@ -499,6 +522,7 @@ let dragShape = null;
       }
       dragIdx = null;
       dragShape = null;
+      canvas.style.cursor = 'default';
     });
 
     canvas.addEventListener('mouseleave', ()=>{
@@ -512,6 +536,7 @@ let dragShape = null;
       }
       dragIdx = null;
       dragShape = null;
+      canvas.style.cursor = 'default';
     });
 
     canvas.addEventListener('dblclick', ()=>{


### PR DESCRIPTION
## Summary
- Restyle the BYG SELV planner with the site's dark theme, Montserrat fonts and accent colors for a consistent look.
- Allow speakers to be grabbed and moved even after drawing rooms, with cursor feedback.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b74a6af61c832babae9f91a67bb816