### PR TITLE
Improve coverage transparency and BYG SELV interactions

### DIFF
--- a/byg-selv.html
+++ b/byg-selv.html
@@ -105,13 +105,12 @@
         <p>Ingen produkter</p>
         <h4>Total: 0 DKK</h4>
         <ul class="ls-legend">
-          <li><span style="background:#0B6623"></span> ≤84 dB</li>
-          <li><span style="background:#1E7A2E"></span> 86 dB</li>
-          <li><span style="background:#2FA84F"></span> 88 dB</li>
-          <li><span style="background:#5FCF73"></span> 91 dB</li>
-          <li><span style="background:#7AD37A"></span> 94 dB</li>
-          <li><span style="background:#A4E1A6"></span> 97 dB</li>
-          <li><span style="background:#CDECCB"></span> ≥100 dB</li>
+          <li><span style="background:#0B6623;opacity:0"></span> ≤86 dB</li>
+          <li><span style="background:#0B6623;opacity:0.2"></span> 88 dB</li>
+          <li><span style="background:#0B6623;opacity:0.4"></span> 91 dB</li>
+          <li><span style="background:#0B6623;opacity:0.6"></span> 94 dB</li>
+          <li><span style="background:#0B6623;opacity:0.8"></span> 97 dB</li>
+          <li><span style="background:#0B6623"></span> ≥100 dB</li>
         </ul>
       </div>
       <div class="ls-cta">
@@ -164,6 +163,8 @@ const measurements = [];
 let currentMeasurement = null;
 let hoverShapeIdx = null;
 let dragShape = null;
+const SPEAKER_PICK_RADIUS = 1;
+let dragOffset = {x:0, y:0};
 
     const heatmapToggle = document.getElementById('heatmap-toggle');
     const roomTool = document.getElementById('room-tool');
@@ -315,7 +316,17 @@ let dragShape = null;
       ctx.restore();
     }
 
+    let renderQueued = false;
     function render(){
+      if(renderQueued) return;
+      renderQueued = true;
+      requestAnimationFrame(()=>{
+        renderQueued = false;
+        drawScene();
+      });
+    }
+
+    function drawScene(){
       ctx.clearRect(0,0,canvas.width,canvas.height);
       if(showHeatmap){
         const grid = calcCoverageGrid({widthM:area.w,heightM:area.h,cellSizeM:1,speakers});
@@ -368,6 +379,29 @@ let dragShape = null;
         ctx.fill();
         ctx.restore();
       });
+      drawRuler();
+    }
+
+    function drawRuler(){
+      const originX = 10;
+      const originY = canvas.height - 10;
+      const lengthM = Math.min(5, area.w);
+      ctx.save();
+      ctx.strokeStyle = '#fff';
+      ctx.fillStyle = '#fff';
+      ctx.beginPath();
+      ctx.moveTo(originX, originY);
+      ctx.lineTo(originX + lengthM*CELL_PX, originY);
+      ctx.stroke();
+      for(let i=0;i<=lengthM;i++){
+        const x = originX + i*CELL_PX;
+        ctx.beginPath();
+        ctx.moveTo(x, originY);
+        ctx.lineTo(x, originY-5);
+        ctx.stroke();
+        ctx.fillText(i+'m', x-6, originY-7);
+      }
+      ctx.restore();
     }
 
     // select drawing tool
@@ -383,10 +417,23 @@ let dragShape = null;
       });
     });
 
-    // Add speaker by clicking product
+    // Add speaker by clicking product with limits
+    const productLimits = {
+      'yamaha-dxr12': 2,
+      'yamaha-dxs12mkii': 1,
+      'dbtech-bhype12': 1
+    };
+    const productCounts = {};
     document.querySelectorAll('.ls-product-list li').forEach((li,idx)=>{
       li.addEventListener('click', ()=>{
         const prod = PRODUCTS_SEED[idx];
+        const limit = productLimits[prod.id] ?? Infinity;
+        const count = productCounts[prod.id] ?? 0;
+        if(count >= limit){
+          alert('Maks antal ' + prod.name + ' nået');
+          return;
+        }
+        productCounts[prod.id] = count + 1;
         speakers.push({x:area.w/2,y:area.h/2,rotDeg:0,productId:prod.id});
         render();
       });
@@ -425,9 +472,11 @@ let dragShape = null;
         return;
       }
 
-      const spIdx = speakers.findIndex(sp=>Math.hypot(sp.x-x, sp.y-y) < 0.5);
+      const spIdx = speakers.findIndex(sp=>Math.hypot(sp.x-x, sp.y-y) < SPEAKER_PICK_RADIUS);
       if(spIdx !== -1){
         dragIdx = spIdx;
+        dragOffset.x = x - speakers[spIdx].x;
+        dragOffset.y = y - speakers[spIdx].y;
         canvas.style.cursor = 'grabbing';
         return;
       }
@@ -532,8 +581,8 @@ let dragShape = null;
         }
         render();
       }else if(dragIdx!==null){
-        speakers[dragIdx].x = x;
-        speakers[dragIdx].y = y;
+        speakers[dragIdx].x = x - dragOffset.x;
+        speakers[dragIdx].y = y - dragOffset.y;
         canvas.style.cursor = 'grabbing';
         render();
       }else{
@@ -549,7 +598,7 @@ let dragShape = null;
           hoverShapeIdx = found;
           render();
         }
-        const overSp = speakers.findIndex(sp=>Math.hypot(sp.x-x, sp.y-y) < 0.5);
+        const overSp = speakers.findIndex(sp=>Math.hypot(sp.x-x, sp.y-y) < SPEAKER_PICK_RADIUS);
         canvas.style.cursor = overSp !== -1 ? 'move' : 'default';
       }
     });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -5,8 +5,9 @@ import {calcCoverageGrid} from '../utils/coverageGrid.js';
 import {PRODUCTS_SEED} from '../PRODUCTS_SEED.js';
 
 // test getCoverageColor
-const color = getCoverageColor(96, {targetSPLdB:94});
-assert.equal(color.hex, '#1E7A2E');
+const color = getCoverageColor(96);
+assert.equal(color.hex, '#0B6623');
+assert.equal(color.alpha, 0.8);
 
 // test dbSum for two equal sources
 const sum = dbSum([90,90]);

--- a/utils/coverageColor.js
+++ b/utils/coverageColor.js
@@ -1,18 +1,17 @@
-export const GREEN_PALETTE = ["#0B6623","#1E7A2E","#2FA84F","#5FCF73","#7AD37A","#A4E1A6","#CDECCB"];
+export const BASE_GREEN = "#0B6623";
 
 export function getCoverageColor(
   splDb,
-  { targetSPLdB, headroomAboveTarget = 6, falloffBelowTarget = 12, minAlpha = 0.08, maxAlpha = 0.9 }
+  _opts = {}
 ){
-  const above = splDb - targetSPLdB;
-  const clamp = (v,a,b)=>Math.min(b,Math.max(a,v));
-  const lerp = (a,b,t)=>a+(b-a)*t;
+  let alpha;
+  if(splDb <= 86) alpha = 0;           // 100% transparent
+  else if(splDb <= 88) alpha = 0.2;    // 80% transparent
+  else if(splDb <= 91) alpha = 0.4;    // 60% transparent
+  else if(splDb <= 94) alpha = 0.6;    // 40% transparent
+  else if(splDb <= 97) alpha = 0.8;    // 20% transparent
+  else if(splDb >= 100) alpha = 1;     // 0% transparent
+  else alpha = 0.8;                    // between 97 and 100 dB
 
-  const norm = above >= 0 ? clamp(above/headroomAboveTarget,0,1) : clamp(above/-falloffBelowTarget,-1,0);
-  const idx  = norm >= 0 ? Math.round(2 - norm*2) : Math.round(4 + (1+norm)*2);
-  const i    = clamp(idx, 0, GREEN_PALETTE.length-1);
-  const alpha= norm >= 0 ? lerp(0.7, maxAlpha, norm) : lerp(minAlpha, 0.6, norm+1);
-  const percent = norm >= 0 ? 50 + Math.round(norm*50) : Math.round((norm+1)*50);
-
-  return { hex: GREEN_PALETTE[i], alpha: Math.round(alpha*1000)/1000, percent, paletteIndex:i };
+  return { hex: BASE_GREEN, alpha: Math.round(alpha*1000)/1000, percent: Math.round(alpha*100), paletteIndex:0 };
 }

--- a/utils/coverageColor.ts
+++ b/utils/coverageColor.ts
@@ -1,18 +1,17 @@
-export const GREEN_PALETTE = ["#0B6623","#1E7A2E","#2FA84F","#5FCF73","#7AD37A","#A4E1A6","#CDECCB"] as const;
+export const BASE_GREEN = "#0B6623" as const;
 
 export function getCoverageColor(
   splDb: number,
-  { targetSPLdB, headroomAboveTarget = 6, falloffBelowTarget = 12, minAlpha = 0.08, maxAlpha = 0.9 }
+  _opts: Record<string, unknown> = {}
 ){
-  const above = splDb - targetSPLdB;
-  const clamp = (v:number,a:number,b:number)=>Math.min(b,Math.max(a,v));
-  const lerp = (a:number,b:number,t:number)=>a+(b-a)*t;
+  let alpha: number;
+  if(splDb <= 86) alpha = 0;           // 100% transparent
+  else if(splDb <= 88) alpha = 0.2;    // 80% transparent
+  else if(splDb <= 91) alpha = 0.4;    // 60% transparent
+  else if(splDb <= 94) alpha = 0.6;    // 40% transparent
+  else if(splDb <= 97) alpha = 0.8;    // 20% transparent
+  else if(splDb >= 100) alpha = 1;     // 0% transparent
+  else alpha = 0.8;                    // between 97 and 100 dB
 
-  const norm = above >= 0 ? clamp(above/headroomAboveTarget,0,1) : clamp(above/-falloffBelowTarget,-1,0);
-  const idx  = norm >= 0 ? Math.round(2 - norm*2) : Math.round(4 + (1+norm)*2);
-  const i    = clamp(idx, 0, GREEN_PALETTE.length-1);
-  const alpha= norm >= 0 ? lerp(0.7, maxAlpha, norm) : lerp(minAlpha, 0.6, norm+1);
-  const percent = norm >= 0 ? 50 + Math.round(norm*50) : Math.round((norm+1)*50);
-
-  return { hex: GREEN_PALETTE[i], alpha: Math.round(alpha*1000)/1000, percent, paletteIndex:i };
+  return { hex: BASE_GREEN, alpha: Math.round(alpha*1000)/1000, percent: Math.round(alpha*100), paletteIndex:0 };
 }


### PR DESCRIPTION
## Summary
- Map SPL values to green heatmap transparency at key dB levels
- Limit number of specific speakers and smooth render loop
- Add permanent ruler and easier speaker dragging

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b756b4b0c4832ba187b97e1b7f1033